### PR TITLE
Base Dock schema mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ your root schema using `allOf` keyword:
 
 This will include all fields from Dock schema:
 
+- `$schema`: denotes what schema was used to build this particular
+  package. It is required to let recipient know what's inside the package.
 - `$originAddress`: original address of the participant that created
   the data within this data package. This should remain unchanged during
   the repackaging process so that the final recipient would know who
   originally created this data (rather than the address of the user who
   repackaged the data)
-- `$recipientAddress`: address of the designated recipient. This is the
-  only field that is changed on every repackage. It is needed to ensure
-  the recipient that the data was indeed designated for him.
+- `$recipientAddress`: address of the designated recipient. It is needed
+  to ensure the recipient that the data was indeed designated for him.
 - `$createdAt`: time value that denotes when original data was created.
   This should remain unchanged during the repackaging process to let the
   recipient see when original data was packaged.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # schemas
 Data schemas provided by Dock
+
+
+# Base Dock schema
+
+In order to provide unified and verifiable protocol operations it is
+important to have few "metadata fields" included in each package.
+
+This is achieved by adding
+[dock base](https://github.com/getdock/schemas/base.json) schema into
+your root schema using `allOf` keyword:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "allOf": [
+    {
+      "$ref": "https://github.com/getdock/schemas/dock.json"
+    }
+  ],
+  "$data": ["..."]
+}
+```
+
+This will include all fields from Dock schema:
+
+- `$originAddress`: original address of the participant that created
+  the data within this data package. This should remain unchanged during
+  the repackaging process so that the final recipient would know who
+  originally created this data (rather than the address of the user who
+  repackaged the data)
+- `$recipientAddress`: address of the designated recipient. This is the
+  only field that is changed on every repackage. It is needed to ensure
+  the recipient that the data was indeed designated for him.
+- `$createdAt`: time value that denotes when original data was created.
+  This should remain unchanged during the repackaging process to let the
+  recipient see when original data was packaged.
+- `$data`: key that stores the package payload.

--- a/connections.json
+++ b/connections.json
@@ -3,6 +3,11 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "User social connections",
   "title": "User network connections",
+  "allOf": [
+    {
+      "$ref": "https://github.com/getdock/schemas/dock.json"
+    }
+  ],
   "definitions": {
     "connection": {
       "type": "object",
@@ -48,14 +53,11 @@
   },
   "type": "object",
   "properties": {
-    "connections": {
+    "$data": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/connection"
       }
     }
-  },
-  "required": [
-    "connections"
-  ]
+  }
 }

--- a/dock.json
+++ b/dock.json
@@ -4,6 +4,11 @@
   "$comment": "Base schema required for every package that is participating in Dock protocol",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string",
+      "$comment": "Key to identify dock-compatible schema that was used to build given data package"
+      "example": "https://github.com/getdock/schemas/dock.json"
+    },
     "$originAddress": {
       "type": "string",
       "format": "ethAddress",
@@ -35,6 +40,7 @@
     }
   },
   "required": [
+    "$schema",
     "$originAddress",
     "$recipientAddress",
     "$createdAt",

--- a/dock.json
+++ b/dock.json
@@ -1,0 +1,43 @@
+{
+  "$id": "https://github.com/getdock/schemas/dock.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "Base schema required for every package that is participating in Dock protocol",
+  "type": "object",
+  "properties": {
+    "$originAddress": {
+      "type": "string",
+      "format": "ethAddress",
+      "example": "0x1234567890AbCdEf000000000000000000000000",
+      "$comment": "Ethereum address of the data creator. This should always remain the same for every package repackaging"
+    },
+    "$recipientAddress": {
+      "type": "string",
+      "format": "ethAddress",
+      "example": "0x1234567890AbCdEf000000000000000000000000",
+      "$comment": "Designated recipient address. This should always be changed on every package resending to match the recipient"
+    },
+    "$createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "example": "2010-10-10T12:20:12.999Z",
+      "$comment": "Date when original package was created. This should remain unchanged during repackage."
+    },
+    "$data": {
+      "$comment": "This is where package payload goes.",
+      "anyOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "required": [
+    "$originAddress",
+    "$recipientAddress",
+    "$createdAt",
+    "$data"
+  ]
+}

--- a/userProfile.json
+++ b/userProfile.json
@@ -3,6 +3,11 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Basic user profile that includes name, email, location and reviews",
   "title": "Dock user profile",
+  "allOf": [
+    {
+      "$ref": "https://github.com/getdock/schemas/dock.json"
+    }
+  ],
   "definitions": {
     "review": {
       "type": "string"
@@ -100,78 +105,83 @@
   },
   "type": "object",
   "properties": {
-    "title": "user",
-    "type": "object",
-    "description": "Properties related to the user object",
-    "properties": {
-      "first_name": {
-        "description": "User's first name",
-        "type": "string"
-      },
-      "last_name": {
-        "description": "User's last name",
-        "type": "string"
-      },
-      "email": {
-        "description": "User's primary email address",
-        "type": "string"
-      },
-      "headline": {
-        "type": "string"
-      },
-      "avatar": {
-        "description": "URL pointing to user's avatar",
-        "type": "string"
-      },
-      "location": {
-        "$ref": "#/definitions/location",
-        "description": "User's address as returned by Google address api"
-      },
-      "city": {
-        "type": "string"
-      },
-      "country": {
-        "type": "string"
-      },
-      "required": [
-        "first_name",
-        "last_name",
-        "email"
-      ]
-    },
-    "profile": {
-      "background": {
-        "type": "string"
-      },
-      "bio": {
-        "type": "string"
-      },
-      "languages": {
-        "type": "array",
-        "items": {
-          "type": "string"
+    "$data": {
+      "type": "object",
+      "properties": {
+        "title": "user",
+        "type": "object",
+        "description": "Properties related to the user object",
+        "properties": {
+          "first_name": {
+            "description": "User's first name",
+            "type": "string"
+          },
+          "last_name": {
+            "description": "User's last name",
+            "type": "string"
+          },
+          "email": {
+            "description": "User's primary email address",
+            "type": "string"
+          },
+          "headline": {
+            "type": "string"
+          },
+          "avatar": {
+            "description": "URL pointing to user's avatar",
+            "type": "string"
+          },
+          "location": {
+            "$ref": "#/definitions/location",
+            "description": "User's address as returned by Google address api"
+          },
+          "city": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "required": [
+            "first_name",
+            "last_name",
+            "email"
+          ]
         },
-        "uniqueItems": true
-      },
-      "phone": {
-        "type": "string"
-      },
-      "phone_country_code": {
-        "type": "string"
-      },
-      "reviews": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/review"
-        }
-      },
-      "status": {
-        "type": "string"
+        "profile": {
+          "background": {
+            "type": "string"
+          },
+          "bio": {
+            "type": "string"
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          },
+          "phone": {
+            "type": "string"
+          },
+          "phone_country_code": {
+            "type": "string"
+          },
+          "reviews": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/review"
+            }
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "user",
+          "profile"
+        ]
       }
-    },
-    "required": [
-      "user",
-      "profile"
-    ]
+    }
   }
 }


### PR DESCRIPTION
In accordance to Dock protocol specifications (at least ones that are  in whitepaper so far) we need to introduce few meta fields to every data package that will be exchanged on Dock protocol to let participants verify sender and recipient of the data package.

This PR introduces a separate schema mixin that should be added to any schema that will participate in Dock protocol.